### PR TITLE
Use realpath() in helpers_get_dir

### DIFF
--- a/acf.php
+++ b/acf.php
@@ -136,7 +136,7 @@ class acf {
         
         
         // if file is in plugins folder
-        $wp_plugin_dir = str_replace('\\' ,'/', WP_PLUGIN_DIR); 
+        $wp_plugin_dir = realpath(str_replace('\\' ,'/', WP_PLUGIN_DIR)); 
         $dir = str_replace($wp_plugin_dir, plugins_url(), $dir, $count);
         
         


### PR DESCRIPTION
The `helpers_get_dir` function doesn't play nicely with symlinks. In our Capistrano set up the `str_replace` call on line 140 is not made because the `$wp_plugin_dir` variable points to the "current" symlink directory, rather than the actual release directory.

This commit fixes that by calling `realpath` to resolve the symlink first.